### PR TITLE
fix: prevent focus stealing

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -1227,6 +1227,8 @@
         };
 
         function onDocumentClick(e) {
+          if (!$select.open) return; //Skip it if dropdown is close
+
           var contains = false;
 
           if (window.jQuery) {
@@ -1238,7 +1240,12 @@
           }
 
           if (!contains && !$select.clickTriggeredSelect) {
-            $select.close(angular.element(e.target).closest('.ui-select-container.open').length > 0); // Skip focusser if the target is another select
+            // Will lose focus only with certain targets
+            var focusableControls = ['input','button','textarea'];
+            var targetScope = angular.element(e.target).scope(); //To check if target is other ui-select
+            var skipFocusser = targetScope && targetScope.$select && targetScope.$select !== $select; //To check if target is other ui-select
+            if (!skipFocusser) skipFocusser =  ~focusableControls.indexOf(e.target.tagName.toLowerCase()); //Check if target is input, button or textarea
+            $select.close(skipFocusser);
             scope.$digest();
           }
           $select.clickTriggeredSelect = false;

--- a/src/select.js
+++ b/src/select.js
@@ -1219,6 +1219,8 @@
         };
 
         function onDocumentClick(e) {
+          if (!$select.open) return; //Skip it if dropdown is close
+
           var contains = false;
 
           if (window.jQuery) {
@@ -1230,7 +1232,12 @@
           }
 
           if (!contains && !$select.clickTriggeredSelect) {
-            $select.close(angular.element(e.target).closest('.ui-select-container.open').length > 0); // Skip focusser if the target is another select
+            // Will lose focus only with certain targets
+            var focusableControls = ['input','button','textarea'];
+            var targetScope = angular.element(e.target).scope(); //To check if target is other ui-select
+            var skipFocusser = targetScope && targetScope.$select && targetScope.$select !== $select; //To check if target is other ui-select
+            if (!skipFocusser) skipFocusser =  ~focusableControls.indexOf(e.target.tagName.toLowerCase()); //Check if target is input, button or textarea
+            $select.close(skipFocusser);
             scope.$digest();
           }
           $select.clickTriggeredSelect = false;


### PR DESCRIPTION
When the user clicks on another input the focus should remain in the new
input and not immediately return to the ui-select.

Heavily based on https://github.com/angular-ui/ui-select/pull/668